### PR TITLE
Preliminary support for repeating groups

### DIFF
--- a/resources/public/css/style.css
+++ b/resources/public/css/style.css
@@ -4,6 +4,12 @@
     stroke-width: 1.5px;
 }
 
+.cluster rect {
+    stroke: #999;
+    fill: #ddd;
+    stroke-width: 1.5px;
+}
+
 .edgePath path {
     stroke: #333;
     stroke-width: 1.5px;

--- a/resources/public/js/externs.js
+++ b/resources/public/js/externs.js
@@ -12,6 +12,7 @@ dagreD3.graphlib.Graph = function() {};
 dagreD3.graphlib.Graph.prototype.setGraph = function() {};
 dagreD3.graphlib.Graph.prototype.setDefaultEdgeLabel = function() {};
 dagreD3.graphlib.Graph.prototype.setNode = function() {};
+dagreD3.graphlib.Graph.prototype.setParent = function() {};
 dagreD3.graphlib.Graph.prototype.setEdge = function() {};
 dagreD3.graphlib.Graph.prototype.graph = function() {};
 dagreD3.intersect.rect = function() {};


### PR DESCRIPTION
This shows repeating groups in the graph as clusters with child nodes. As a consequence of this UI metaphor, there can currently only be one of each repeating group, i.e. always one W-2, never two W-2s or zero W-2s.